### PR TITLE
ci: declare contents: read for the bazel test workflow

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Tiny hardening change. The single `bazel_test` job in `.github/workflows/bazel-test.yaml` only checks out the repo and runs `bazel test` with remote cache via Google service-account credentials (passed as the `GOOGLE_CREDENTIALS` secret). It does not write to the repo or call GitHub APIs for any write, so the workflow's `GITHUB_TOKEN` only needs `contents: read`.

YAML parses cleanly (`python -c 'import yaml; yaml.safe_load(...)'`).